### PR TITLE
Add ENE KB930 EC support & confirm several autoport issues

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -54,7 +54,7 @@ config MMCONF_BASE_ADDRESS
 	hex
 	default 0xf0000000
 
-config DRAM_RESET_GATE_GPIO # FIXME: check this
+config DRAM_RESET_GATE_GPIO
 	int
 	default 60
 

--- a/acpi/ec.asl
+++ b/acpi/ec.asl
@@ -1,7 +1,25 @@
-Device(EC)
+/*
+ * This file is part of the coreboot project.
+ *
+ * Copyright (C) 2011-2012 The Chromium OS Authors. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; version 2 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc.
+ */
+
+#include <ec/compal/ene932/acpi/ec.asl>
+
+Scope(\_SB.PCI0.LPCB.EC0)
 {
-	Name (_HID, EISAID("PNP0C09"))
-	Name (_UID, 0)
-	Name (_GPE, 23)
-/* FIXME: EC support */
 }

--- a/acpi/superio.asl
+++ b/acpi/superio.asl
@@ -1,1 +1,23 @@
-#include <drivers/pc80/ps2_controller.asl>
+/*
+ * This file is part of the coreboot project.
+ *
+ * Copyright (C) 2012 The ChromiumOS Authors.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc.
+ */
+
+/* mainboard configuration */
+
+#define SIO_EC_ENABLE_PS2K       // Enable PS/2 Keyboard
+#define SIO_ENABLE_PS2M          // Enable PS/2 Mouse

--- a/acpi_tables.c
+++ b/acpi_tables.c
@@ -1,1 +1,40 @@
-/* dummy */
+/*
+ * This file is part of the coreboot project.
+ *
+ * Copyright (C) 2007-2009 coresystems GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <arch/acpigen.h>
+#include <southbridge/intel/bd82x6x/nvs.h>
+#include "thermal.h"
+
+static void acpi_update_thermal_table(global_nvs_t *gnvs)
+{
+	gnvs->tcrt = CRITICAL_TEMPERATURE;
+	gnvs->tpsv = PASSIVE_TEMPERATURE;
+}
+
+void acpi_create_gnvs(global_nvs_t *gnvs)
+{
+	/* Disable USB ports in S3 by default */
+	gnvs->s3u0 = 0;
+	gnvs->s3u1 = 0;
+
+	/* Disable USB ports in S5 by default */
+	gnvs->s5u0 = 0;
+	gnvs->s5u1 = 0;
+
+	// the lid is open by default.
+	gnvs->lids = 1;
+
+	acpi_update_thermal_table(gnvs);
+}

--- a/board_info.txt
+++ b/board_info.txt
@@ -1,4 +1,6 @@
 Category: laptop
+ROM package: SOIC-8
 ROM protocol: SPI
+ROM socketed: n
 Flashrom support: n
-FIXME: put ROM package, ROM socketed, Release year
+Release year: 2012

--- a/thermal.h
+++ b/thermal.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the coreboot project.
+ *
+ * Copyright (C) 2011 The Chromium OS Authors. All rights reserved.
+ * Copyright (C) 2014 Vladimir Serbinenko
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef ASPIRE_E1-571_THERMAL_H
+#define ASPIRE_E1-571_THERMAL_H
+
+	/* Temperature which OS will shutdown at */
+	#define CRITICAL_TEMPERATURE	100
+
+	/* Temperature which OS will throttle CPU */
+	#define PASSIVE_TEMPERATURE	90
+
+#endif


### PR DESCRIPTION
These commits should fix some things that the autoport script left out, such as support for the ENE KB930 EC (issue #1), the missing board info (issue #2), and confirming that `DRAM_RESET_GATE_GPIO` is 60 (issue #5).

For further reference, this laptop uses a Compal LA-7912P, and the datasheet for this is easily found online. I would recommend looking at it, it's a useful resource for any further changes to the port.
